### PR TITLE
Changed string defaults in spec.yml to numbers

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -1107,7 +1107,7 @@ definitions:
   LineItem:
     properties:
       quantity:
-        default: '0'
+        default: 0
         type: number
         format: double
       id:
@@ -1150,7 +1150,7 @@ definitions:
   Inventory:
     properties:
       quantity:
-        default: '0'
+        default: 0
         type: number
         format: double
       id:


### PR DESCRIPTION
Looked like `Inventory` and `LineItem` objects in [spec.yml](https://github.com/IBM-Bluemix/logistics-wizard-erp/blob/master/spec.yaml) should have numerical default values. It was throwing errors in the Swagger editor as well. If those string defaults were needed for some reason, just reject the PR and close it