### PR TITLE
Use transactions where needed

### DIFF
--- a/common/models/erp-user.js
+++ b/common/models/erp-user.js
@@ -19,6 +19,7 @@ module.exports = function (ErpUser) {
 
   // hide the link back to the demo
   helper.hideRelation(ErpUser, "demo");
+  helper.hideRelation(ErpUser, "accessTokens");
   helper.readOnlyRelation(ErpUser, "roles");
 
   // callback(err, principal)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "loopback": "^2.29.0",
     "loopback-boot": "^2.19.0",
     "loopback-component-explorer": "^2.5.0",
-    "loopback-connector-memory-idstr": "^1.0.0",
     "loopback-connector-postgresql": "^2.6.3",
     "loopback-datasource-juggler": "^2.46.1",
     "randomstring": "^1.1.5",


### PR DESCRIPTION
Shipment updates were really the only place where we needed to run the API calls with a transaction given they touch multiple tables.